### PR TITLE
feat: QI parameters fetched based on frequencies

### DIFF
--- a/vesta_si_erpnext/hooks.py
+++ b/vesta_si_erpnext/hooks.py
@@ -97,6 +97,9 @@ doctype_js = {
 fixtures = ["Custom Field"]
 
 doc_events = {
+	"Quality Inspection Template": {
+		"validate": "vesta_si_erpnext.vesta_si_erpnext.quality_inspection_template.validate"
+	},
 	"Quality Inspection": {
 		"validate": "vesta_si_erpnext.vesta_si_erpnext.quality_inspection.validate_events",
 		"on_submit": "vesta_si_erpnext.vesta_si_erpnext.quality_inspection.on_submit_events"

--- a/vesta_si_erpnext/patches.txt
+++ b/vesta_si_erpnext/patches.txt
@@ -1,1 +1,2 @@
-vesta_si_erpnext.patches.create_se_pr_qi_custom_fields #27-01-2021
+vesta_si_erpnext.patches.create_se_pr_qi_custom_fields
+vesta_si_erpnext.patches.create_qit_custom_fields 

--- a/vesta_si_erpnext/patches/create_qit_custom_fields.py
+++ b/vesta_si_erpnext/patches/create_qit_custom_fields.py
@@ -1,0 +1,24 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def execute():
+
+    qi_template_fields = [
+		dict(fieldname='item_name', label='Item', fieldtype='Link',
+			insert_after='quality_inspection_template_name', options='Item')
+	]
+    qi_reading_fields = [
+		dict(fieldname='frequency', label='Frequency', fieldtype='Int',
+			insert_after='specification', hidden = 1)
+	]
+    iqip_fields = [
+		dict(fieldname='frequency', label='Frequency', fieldtype='Int',
+			insert_after='specification', in_list_view = 1)
+	]
+
+    custom_fields = {
+		"Quality Inspection Template": qi_template_fields,
+        "Quality Inspection Reading": qi_reading_fields,
+        "Item Quality Inspection Parameter": iqip_fields
+	}
+    create_custom_fields(custom_fields, update=True)
+

--- a/vesta_si_erpnext/public/js/quality_inspection.js
+++ b/vesta_si_erpnext/public/js/quality_inspection.js
@@ -33,12 +33,17 @@ frappe.ui.form.on("Quality Inspection", {
 						doc: frm.doc
 					},
 					callback: function(res) {
+						if (Object.keys(res.message).length == 1) {
+							frm.set_value("quality_inspection_template", res.message.template);
+						}
+						else {
 						frm.doc.quality_inspection_template = res.message.template;
 						for (const [key, value] of Object.entries(res.message.freq_readings)) {
 							frm.add_child("readings", value);
 						}
 						refresh_field(['quality_inspection_template', 'readings']);
 						frm.events.auto_fill_inspection_summary(frm, true);
+						}
 					}
 				});
 			} else {

--- a/vesta_si_erpnext/public/js/quality_inspection.js
+++ b/vesta_si_erpnext/public/js/quality_inspection.js
@@ -25,10 +25,18 @@ frappe.ui.form.on("Quality Inspection", {
 		if (frm.doc.item_code) {
 			if (!frm.doc.analysed_item_code) {
 				// if no analysed item code, overwrite tables, analysis isnt done
+				frm.doc.readings = []
+				// gets only paramters where frequency of the parameter is equal/multiple of drum_no
 				frappe.call({
-					method: "get_quality_inspection_template",
-					doc: frm.doc,
-					callback: function() {
+					method: "vesta_si_erpnext.vesta_si_erpnext.quality_inspection.get_frequency_specific_parameters",
+					args: {
+						doc: frm.doc
+					},
+					callback: function(res) {
+						frm.doc.quality_inspection_template = res.message.template;
+						for (const [key, value] of Object.entries(res.message.freq_readings)) {
+							frm.add_child("readings", value);
+						}
 						refresh_field(['quality_inspection_template', 'readings']);
 						frm.events.auto_fill_inspection_summary(frm, true);
 					}
@@ -56,9 +64,8 @@ frappe.ui.form.on("Quality Inspection", {
 				});
 			}
 		}
-
 	},
-
+	
 	quality_inspection_template: function(frm) {
 		if (frm.doc.quality_inspection_template && !frm.doc.analysed_item_code) {
 			frm.events.auto_fill_inspection_summary(frm, false);

--- a/vesta_si_erpnext/public/js/quality_inspection.js
+++ b/vesta_si_erpnext/public/js/quality_inspection.js
@@ -134,3 +134,24 @@ frappe.ui.form.on("Quality Inspection", {
 		}
 	}
 })
+frappe.ui.form.on('Quality Inspection Reading', {
+	specification(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.specification) {
+			frappe.xcall("vesta_si_erpnext.vesta_si_erpnext.quality_inspection.get_min_max_values", {
+				"template": frm.doc.quality_inspection_template, 
+				"parameter": row.specification
+			})
+			.then((values) => {
+				row.min_value = values.min;
+				row.max_value = values.max;
+				frm.refresh_fields("readings");
+			})
+		}
+		else {
+			row.min_value = 0;
+			row.max_value = 0;
+			frm.refresh_fields("readings");
+		}
+	}
+})

--- a/vesta_si_erpnext/public/js/stock_entry.js
+++ b/vesta_si_erpnext/public/js/stock_entry.js
@@ -44,6 +44,28 @@ frappe.ui.form.on("Stock Entry", {
 });
 
 frappe.ui.form.on("Stock Entry Detail", {
+	batch_no(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (!row.is_finished_item) {
+			frappe.db
+				.get_list("Quality Inspection", {
+					filters: {"batch_no": row.batch_no},
+					fields: ["name"],
+					order_by: "creation desc",
+					limit: 1,
+				})
+				.then((res) => {
+					console.log(res.length)
+					if (!res.length) {
+						row.quality_inspection = "";
+					}
+					else {
+						row.quality_inspection = res[0].name;
+					}
+					frm.refresh_fields("items");
+				})
+		}
+	},
 	quality_inspection: function(frm, cdt, cdn) {
 		let row = locals[cdt][cdn];
 

--- a/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
@@ -215,6 +215,7 @@ def get_frequency_specific_parameters(doc):
 	ref_doc = frappe.get_doc(doc.reference_type, doc.reference_name)
 	fg_idx = None
 	batch_idx = None
+	drum_no = None
 	for item in ref_doc.get("items"):
 		if item.is_finished_item:
 			if item.get("batch_no") == doc.batch_no:
@@ -223,7 +224,11 @@ def get_frequency_specific_parameters(doc):
 		else:
 			fg_idx = item.idx
 
-	drum_no = cint(batch_idx) - cint(fg_idx)
+	if cint(batch_idx) >= cint(fg_idx):
+		drum_no = cint(batch_idx) - cint(fg_idx)
+
+	if not drum_no:
+		return {"template": template}
 
 	freq_readings = {}
 	idx = 1

--- a/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
@@ -16,6 +16,7 @@ def on_submit_events(doc, method=None):
 	validate_analysis(doc)
 
 	if doc.reference_type == "Stock Entry":
+
 		update_qc_reference_as_per_frequency(doc)
 
 def accept_reject_inspection(doc):
@@ -102,7 +103,6 @@ def run_analysis(readings=None, priority_list=None):
 
 def analyse_item(readings, template):
 	template_params = get_template_details(template)
-
 	results, rejected_params = [], []
 	for reading in readings:
 		# inspect every input reading parameter/specification
@@ -193,6 +193,47 @@ def get_template_details(template):
 		param_wise_inspection[row.specification] = row
 
 	return param_wise_inspection
+
+def get_template_details_with_frequency(template):
+
+	if not template: return []
+
+	return frappe.get_all('Item Quality Inspection Parameter',
+		fields=["specification", "frequency", "value", "acceptance_formula",
+			"numeric", "formula_based_criteria", "min_value", "max_value"],
+		filters={'parenttype': 'Quality Inspection Template', 'parent': template},
+		order_by="idx")
+
+@frappe.whitelist()
+def get_frequency_specific_parameters(doc):
+	doc = frappe._dict(json.loads(doc))
+	template = ''
+	template = frappe.db.get_value('Item', doc.item_code, 'quality_inspection_template')
+	doc.quality_inspection_template = template
+	template_readings = get_template_details_with_frequency(template)
+
+	ref_doc = frappe.get_doc(doc.reference_type, doc.reference_name)
+	fg_idx = None
+	batch_idx = None
+	for item in ref_doc.get("items"):
+		if item.is_finished_item:
+			if item.get("batch_no") == doc.batch_no:
+				batch_idx = item.idx
+				break
+		else:
+			fg_idx = item.idx
+
+	drum_no = cint(batch_idx) - cint(fg_idx)
+
+	freq_readings = {}
+	idx = 1
+	for row in template_readings:
+		if cint(drum_no) % cint(row.frequency) == 0:
+			row.idx = idx
+			freq_readings[row.specification] = row
+			idx += 1
+
+	return {"freq_readings": freq_readings, "template": template}
 
 def convert_from_string(value):
 	if isinstance(value, string_types):

--- a/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
@@ -240,6 +240,21 @@ def get_frequency_specific_parameters(doc):
 
 	return {"freq_readings": freq_readings, "template": template}
 
+@frappe.whitelist()
+def get_min_max_values(template, parameter):
+	template_readings = get_template_details_with_frequency(template)
+	readings = {}
+	for reading in template_readings:
+		readings[reading.specification] = {
+			"min": reading.min_value,
+			"max": reading.max_value
+		}
+	
+	if parameter not in readings:
+		readings[parameter] = {"min": 0, "max": 0}
+
+	return readings[parameter]
+
 def convert_from_string(value):
 	if isinstance(value, string_types):
 		return json.loads(value)

--- a/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/quality_inspection.py
@@ -233,7 +233,7 @@ def get_frequency_specific_parameters(doc):
 	freq_readings = {}
 	idx = 1
 	for row in template_readings:
-		if cint(drum_no) % cint(row.frequency) == 0:
+		if cint(drum_no) % cint(row.frequency) == 0 or cint(drum_no) == 1:
 			row.idx = idx
 			freq_readings[row.specification] = row
 			idx += 1

--- a/vesta_si_erpnext/vesta_si_erpnext/quality_inspection_template.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/quality_inspection_template.py
@@ -1,0 +1,13 @@
+
+import frappe
+from frappe.utils import cint
+
+def validate(doc, method = None):
+    set_lowest_freqency_in_item(doc)
+    
+def set_lowest_freqency_in_item(doc):
+    params = doc.get("item_quality_inspection_parameter")
+    freqs = [param.frequency for param in params]
+    freq = min(freqs)
+    frappe.db.set_value("Item", doc.item_name, "analysis_frequency", cint(freq))
+        


### PR DESCRIPTION
### Changes
- Parameters are now fetched based on the frequencies set in the QI template and the Drum No. of the item in the table.
- 1st drum gets all parameters irrespective of frequencies.
- If a new parameter is manually added, the min/max values are fetched if present in the template.