### PR TITLE
feat: Ability to select multiple rows in 'Batch-Wise Balance and Inspection' report and create SE / certificate 

### DIFF
--- a/vesta_si_erpnext/hooks.py
+++ b/vesta_si_erpnext/hooks.py
@@ -35,7 +35,8 @@ app_license = "MIT"
 # include js in doctype views
 doctype_js = {
 	"Quality Inspection" : "public/js/quality_inspection.js",
-	"Stock Entry": "public/js/stock_entry.js"
+	"Stock Entry": "public/js/stock_entry.js",
+	"Quality Inspection Parameter": "public/js/quality_inspection_parameter.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/vesta_si_erpnext/public/js/quality_inspection_parameter.js
+++ b/vesta_si_erpnext/public/js/quality_inspection_parameter.js
@@ -1,0 +1,27 @@
+frappe.ui.form.on('Quality Inspection Parameter', {
+    onload: function(frm) {
+		
+		frappe.model.with_doctype("Analytical Certificate Drum", () => {
+			var fields = $.map(frappe.get_doc("DocType", "Analytical Certificate Drum").fields, function(d) {
+				if (frappe.model.no_value_type.indexOf(d.fieldtype) === -1 || ['Button'].includes(d.fieldtype)) {
+					return { label: d.label , value: d.fieldname };
+				} else {
+					return null;
+				}
+			});
+			
+			frm.set_df_property("certificate_parameter_column", "options", fields);
+			frm.refresh_field("certificate_parameter_column");
+			
+			
+		});
+	},
+    certificate_parameter_column: function(frm, doctype, name) {
+		var doc = frappe.get_doc(doctype, name);
+		var df = $.map(frappe.get_doc("DocType", "Analytical Certificate Drum").fields, function(d) {
+			return doc.certificate_parameter_column == d.fieldname ? d : null;
+		})[0];
+		doc.certificate_column_name = df.fieldname
+		frm.refresh_field("certificate_column_name");
+	},
+})

--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.js
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.js
@@ -137,6 +137,7 @@ frappe.query_reports["Batch-Wise Balance and Inspection"] = {
     },
 
     onload: function(report) {
+		// create SE
         report.page.add_inner_button(__("Create Stock Entry"), function() {
 		if (item_dict.length == 0)
 			frappe.throw("Select atleast 1 row to create a Stock Entry!")
@@ -148,7 +149,19 @@ frappe.query_reports["Batch-Wise Balance and Inspection"] = {
 			frappe.set_route("Form", 'Stock Entry', stock_entry.name);
 			});
 		})
-		item_dict = []
+
+		// create certificate
+		report.page.add_inner_button(__("Create Certificate"), function() {
+			if (item_dict.length == 0)
+				frappe.throw("Select atleast 1 row to create a Certificate!")
+			frappe.xcall(
+			'vesta_si_erpnext.vesta_si_erpnext.report.batch_wise_balance_and_inspection.batch_wise_balance_and_inspection.create_certificate', {
+				item_list: item_dict,
+				}).then(analytical_certificate => {
+				frappe.model.sync(analytical_certificate);
+				frappe.set_route("Form", 'Stock Entry', analytical_certificate.name);
+				});
+			})
 
 	}
 }

--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.js
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.js
@@ -104,15 +104,14 @@ frappe.query_reports["Batch-Wise Balance and Inspection"] = {
 			checkboxColumn: true,
 			events: {
 				onCheckRow: function(data) {
-					console.log('adding now')
 					item_dict.push({
 						"item_code" : data[2].content,
 						"batch_no" : data[5].content,
 						"warehouse" : data[4].content,
 						"qty": data[6].content,
 						"uom": data[7].content,
-						"qi": data[8].content
-					})				
+						"quality_inspection": data[8].content,
+					})
 				},
 			}
 		});
@@ -154,12 +153,13 @@ frappe.query_reports["Batch-Wise Balance and Inspection"] = {
 		report.page.add_inner_button(__("Create Certificate"), function() {
 			if (item_dict.length == 0)
 				frappe.throw("Select atleast 1 row to create a Certificate!")
+
 			frappe.xcall(
 			'vesta_si_erpnext.vesta_si_erpnext.report.batch_wise_balance_and_inspection.batch_wise_balance_and_inspection.create_certificate', {
 				item_list: item_dict,
 				}).then(analytical_certificate => {
 				frappe.model.sync(analytical_certificate);
-				frappe.set_route("Form", 'Stock Entry', analytical_certificate.name);
+				frappe.set_route("Form", 'Analytical Certificate Creation', analytical_certificate.name);
 				});
 			})
 

--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.js
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.js
@@ -96,9 +96,27 @@ frappe.xcall(
 			});
 		}
 	})
-
+let item_dict = [];
 frappe.query_reports["Batch-Wise Balance and Inspection"] = {
 	"filters": filters,
+	get_datatable_options(options) {
+		return Object.assign(options, {
+			checkboxColumn: true,
+			events: {
+				onCheckRow: function(data) {
+					console.log('adding now')
+					item_dict.push({
+						"item_code" : data[2].content,
+						"batch_no" : data[5].content,
+						"warehouse" : data[4].content,
+						"qty": data[6].content,
+						"uom": data[7].content,
+						"qi": data[8].content
+					})				
+				},
+			}
+		});
+	},
 	"formatter": function (value, row, column, data, default_formatter) {
 		if (column.fieldname == "Batch" && data && !!data["Batch"]) {
 			value = data["Batch"];
@@ -114,5 +132,23 @@ frappe.query_reports["Batch-Wise Balance and Inspection"] = {
 		};
 
 		frappe.set_route("query-report", "Stock Ledger");
+
+
+    },
+
+    onload: function(report) {
+        report.page.add_inner_button(__("Create Stock Entry"), function() {
+		if (item_dict.length == 0)
+			frappe.throw("Select atleast 1 row to create a Stock Entry!")
+		frappe.xcall(
+		'vesta_si_erpnext.vesta_si_erpnext.report.batch_wise_balance_and_inspection.batch_wise_balance_and_inspection.create_stock_entry', {
+			item_list: item_dict,
+			}).then(stock_entry => {
+			frappe.model.sync(stock_entry);
+			frappe.set_route("Form", 'Stock Entry', stock_entry.name);
+			});
+		})
+		item_dict = []
+
 	}
 }

--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
@@ -203,27 +203,6 @@ def create_certificate(item_list):
 		qi_doc = frappe.get_doc("Quality Inspection",item_details["quality_inspection"])
 		qi_readings = qi_doc.get("readings")
 		for qi in qi_readings:
-			if 'Iron Content' in qi.specification:
-				drum_child.fe_wt = qi.reading_1
-			if  'Aluminium Content' in qi.specification:
-				drum_child.al_wt = qi.reading_1
-			if 'Calcium Content' in qi.specification:
-				drum_child.ca_wt = qi.reading_1
-			if 'Oxygen Content' in qi.specification:
-				drum_child.o_wt = qi.reading_1
-			if 'Carbon Content' in qi.specification:
-				drum_child.c_wt = qi.reading_1
-			if 'Alpha Phase Content' in qi.specification:
-				drum_child.alpha_beta = qi.reading_1
-			if 'Free Silicon' in qi.specification:
-				drum_child.si_wt = qi.reading_1
-			if 'Specific Surface Area' in qi.specification:
-				drum_child.bet = qi.reading_1
-			if 'D10' in qi.specification:
-				drum_child.d10 = qi.reading_1
-			if 'D50' in qi.specification:
-				drum_child.d50 = qi.reading_1
-			if 'D90' in qi.specification:
-				drum_child.d90 = qi.reading_1
-			
+			mapped_column = frappe.get_value("Quality Inspection Parameter",qi.specification,"certificate_column_name")
+			drum_child.set(mapped_column,qi.reading_1)
 	return analytical_certificate.as_dict()

--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
@@ -195,7 +195,7 @@ def create_certificate(item_list):
 	analytical_certificate.item_code = item_code
 	analytical_certificate.item_name = frappe.get_value("Item",item_code,"item_name")
 	
-	for item_details in item_list_obj:	
+	for item_details in final_list:	
 		if item_details["item_code"] != item_code:					
 			frappe.throw("Please select rows of same Item Code, to create a certificate!")
 		drum_child = analytical_certificate.append('batches')

--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import json
 import frappe
 from frappe import _
 from frappe.utils import cint, flt, getdate
+from pypika.terms import JSON
 
 
 def execute(filters=None):
@@ -150,3 +152,34 @@ def get_item_details(filters):
 		item_map.setdefault(d.name, d)
 
 	return item_map
+
+@frappe.whitelist()
+def create_stock_entry(item_list):
+	stock_entry = frappe.new_doc('Stock Entry')
+	stock_entry.purpose = 'Material Transfer'
+
+	item_list_obj = json.loads(item_list)
+	final_list = [dict(t) for t in {tuple(d.items()) for d in item_list_obj}]
+
+	for item_details in final_list:							
+		se_child = stock_entry.append('items')
+		se_child.s_warehouse = item_details["warehouse"]
+		se_child.item_code = item_details['item_code']
+		se_child.uom = item_details["uom"] 
+		se_child.qty = flt(item_details["qty"], se_child.precision("qty"))
+		se_child.quality_inspection = item_details['qi']
+		for field in ["idx", "po_detail", "original_item", "expense_account",
+			"description", "item_name", "serial_no", "batch_no", "allow_zero_valuation_rate"]:
+			if item_details.get(field):
+				se_child.set(field, item_details.get(field))
+
+		if se_child.s_warehouse==None:
+			se_child.s_warehouse = stock_entry.from_warehouse
+		if se_child.t_warehouse==None:
+			se_child.t_warehouse = stock_entry.to_warehouse
+
+		se_child.transfer_qty = flt(item_details["qty"], se_child.precision("qty"))
+
+	stock_entry.set_stock_entry_type()
+
+	return stock_entry.as_dict()


### PR DESCRIPTION
User can select multiple rows from Batch-Wise Balance and Inspection report and click on 'Create Stock Entry' button.
![image](https://user-images.githubusercontent.com/12999179/149966891-209c0a73-0a57-4e0f-930c-4992171575a0.png)

A new SE is created of type 'Material Transfer' with all the selected rows populated in the item table. User can then edit and submit the record.
![image](https://user-images.githubusercontent.com/12999179/149967221-250b1d21-2393-4e12-b8f0-7981025d1d21.png)


Similarly, user can click on 'Create Certificate' button. A new Analytical Certificate is created with all the selected rows populated in the batches table. The readings/values of the parameters are obtained from the corresponding QI of the selected rows.
![image](https://user-images.githubusercontent.com/12999179/149968010-77f23346-4f88-4fab-af6d-a46e34bf0b12.png)


The parameters have no mapping to the columns in the batches table of the Analytical Certificate doctype. Hence had to hard code them. Also, fetching values of only those parameters that have a relevant column in the batches table currently.