### PR TITLE
fix: Batch-Wise Balance and Inspection report's item_code ambiguous i…

### DIFF
--- a/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
+++ b/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py
@@ -64,7 +64,7 @@ def get_conditions(filters, params):
 
 	for field in ["item_code", "warehouse", "batch_no", "company"]:
 		if filters.get(field):
-			conditions += " and {0} = {1}".format(field, frappe.db.escape(filters.get(field)))
+			conditions += " and s.{0} = {1}".format(field, frappe.db.escape(filters.get(field)))
 
 	for param in params:
 		if filters.get(param['col_name']):
@@ -102,7 +102,7 @@ def get_stock_ledger_entries(filters, params):
 		where s.is_cancelled = 0 and s.docstatus < 2 and ifnull(s.batch_no, '') != '' %s
 		group by voucher_no, batch_no, s.item_code, warehouse
 		order by s.item_code, warehouse""" %
-		(col_conditions, param_conditions, conditions), as_dict=1, debug=1)
+		(col_conditions, param_conditions, conditions), as_dict=1)
 
 def get_item_warehouse_batch_map(filters, float_precision, params):
 	sle = get_stock_ledger_entries(filters, params)


### PR DESCRIPTION
While accesing Batch Wise Balance and Inspection report with Item Code filters getting below error

```
Traceback (most recent call last):  "apps/vesta_si_erpnext/vesta_si_erpnext/vesta_si_erpnext/report/batch_wise_balance_and_inspection/batch_wise_balance_and_inspection.py", line 105, in get_stock_ledger_entries
    (col_conditions, param_conditions, conditions), as_dict=1, debug=1)
  File "apps/frappe/frappe/database/database.py", line 180, in sql
    self._cursor.execute(query)
  File "env/lib/python3.7/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.7/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.7/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.7/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1052, "Column 'item_code' in where clause is ambiguous")
```